### PR TITLE
Implement tags and exams schema, fix calendar logic

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -73,29 +73,7 @@ export default function CalendarPage() {
 
         if (schedulesError) throw schedulesError
 
-        // Convert schedule times to 50-minute blocks starting from 6:00 AM
-        const formattedSchedules = schedulesData?.map(schedule => {
-          // Get the base date (using the schedule's date but with fixed times)
-          const baseDate = new Date(schedule.start_time.split('T')[0])
-          
-          // Calculate hours and minutes based on period number (1-12)
-          const periodNumber = schedule.period || 1
-          const startHour = 6 + Math.floor((periodNumber - 1) * 50 / 60)
-          const startMinute = ((periodNumber - 1) * 50) % 60
-          
-          // Set start time (6:00, 6:50, 7:40, etc.)
-          const startTime = new Date(baseDate)
-          startTime.setHours(startHour, startMinute, 0, 0)
-          
-          // End time is 50 minutes later
-          const endTime = new Date(startTime.getTime() + 50 * 60 * 1000)
-          
-          return {
-            ...schedule,
-            start_time: startTime.toISOString(),
-            end_time: endTime.toISOString()
-          }
-        }) || []
+        const formattedSchedules = schedulesData || []
 
         setSubjects(subjectsData || [])
         setSchedules(formattedSchedules)
@@ -266,7 +244,7 @@ export default function CalendarPage() {
           {daysInWeek.map((date, index) => {
             const daySchedules = schedules.filter((schedule) => {
               const scheduleDate = new Date(schedule.start_time)
-              return scheduleDate.getDay() === (date.getDay() + 6) % 7 + 1 // Adjust for week start on Monday
+              return scheduleDate.getDay() === date.getDay()
             })
 
             return (

--- a/src/lib/supabase/schema.ts
+++ b/src/lib/supabase/schema.ts
@@ -42,6 +42,41 @@ export interface Schedule {
 }
 
 /**
+ * Tags table
+ * Categorises schedules and exams
+ */
+export interface Tag {
+  id: string
+  name: string
+  type: string
+  color: string
+  is_active: boolean
+  created_at: string
+}
+
+/**
+ * Exams table
+ * Stores exam schedules
+ */
+export interface Exam {
+  id: string
+  subject_id: string | null
+  subject_code: string
+  subject_name: string
+  group_class: string | null
+  exam_date: string
+  exam_type: string
+  campus: string | null
+  room: string | null
+  day_of_week: number | null
+  start_time: string
+  duration_minutes: number | null
+  semester: string
+  tag_id: string | null
+  created_at: string
+}
+
+/**
  * Notes table
  * Stores study notes related to specific lessons
  */
@@ -100,6 +135,8 @@ export interface DatabaseTables {
   notes: Note
   lessons: Lesson
   tasks: Task
+  tags: Tag
+  exams: Exam
 }
 
 /**

--- a/supabase-table.md
+++ b/supabase-table.md
@@ -73,6 +73,7 @@ create table public.schedules (
   campus text null,
   week_start integer null,
   week_end integer null,
+  tag_id uuid null,
   color text null,
   notes text null,
   created_at timestamp without time zone null default now(),
@@ -80,6 +81,7 @@ create table public.schedules (
 ) TABLESPACE pg_default;
 
 create index IF not exists idx_schedules_day_week on public.schedules using btree (day, week_start, week_end) TABLESPACE pg_default;
+create index IF not exists idx_schedules_tag on public.schedules using btree (tag_id) TABLESPACE pg_default;
 
 
 
@@ -131,3 +133,41 @@ create table public.tasks (
   created_at timestamp with time zone null default now(),
   constraint tasks_pkey primary key (id)
 ) TABLESPACE pg_default;
+
+
+Tags
+
+create table public.tags (
+  id uuid not null default gen_random_uuid (),
+  name text not null,
+  type text not null,
+  color text not null,
+  is_active boolean not null default true,
+  created_at timestamp with time zone null default now(),
+  constraint tags_pkey primary key (id)
+) TABLESPACE pg_default;
+
+
+Exams
+
+create table public.exams (
+  id uuid not null default gen_random_uuid (),
+  subject_id uuid null,
+  subject_code text not null,
+  subject_name text not null,
+  group_class text null,
+  exam_date text not null,
+  exam_type text not null,
+  campus text null,
+  room text null,
+  day_of_week integer null,
+  start_time text not null,
+  duration_minutes integer null,
+  semester text not null,
+  tag_id uuid null,
+  created_at timestamp with time zone null default now(),
+  constraint exams_pkey primary key (id),
+  constraint exams_subject_id_fkey foreign key (subject_id) references subjects (id) on delete cascade
+) TABLESPACE pg_default;
+
+create index IF not exists idx_exams_tag on public.exams using btree (tag_id) TABLESPACE pg_default;


### PR DESCRIPTION
## Summary
- expand database schema with **tags** and **exams** tables
- allow schedules to store a `tag_id` and index it
- add Tag and Exam types in supabase schema typings
- fix calendar view to use stored schedule times correctly

## Testing
- `npm install`
- `npm run lint` *(fails: React Hook dependencies and type linting errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e8fd8dae08329935c7e592e8baf71