### PR TITLE
Fix schedule insertion and add tag/exam schema

### DIFF
--- a/src/app/calendar/new/page.tsx
+++ b/src/app/calendar/new/page.tsx
@@ -276,8 +276,8 @@ export default function NewCalendarPage() {
           }
 
           const startDate = new Date("2025-06-16")
-          const dayMapping = { "2": 1, "3": 2, "4": 3, "5": 4, "6": 5, "7": 6, "CN": 0 }
-          const dayOfWeek = dayMapping[item.day as keyof typeof dayMapping] || 1
+          const dayMapping = { "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "CN": 8 }
+          const dayOfWeek = dayMapping[item.day as keyof typeof dayMapping] || 2
 
           for (const week of item.weeks) {
             const weekOffset = (week - 25) * 7
@@ -297,6 +297,7 @@ export default function NewCalendarPage() {
             await supabase.from("schedules").insert({
               subject_id: subjectId,
               title: item.subjectName,
+              day: dayOfWeek,
               start_time: startTime.toISOString(),
               end_time: endTime.toISOString(),
               room: item.room,
@@ -380,8 +381,8 @@ export default function NewCalendarPage() {
       }
 
       const startDate = new Date("2025-06-16")
-      const dayMapping = { "2": 1, "3": 2, "4": 3, "5": 4, "6": 5, "7": 6, "CN": 0 }
-      const dayOfWeek = dayMapping[formData.day as keyof typeof dayMapping] || 1
+      const dayMapping = { "2": 2, "3": 3, "4": 4, "5": 5, "6": 6, "7": 7, "CN": 8 }
+      const dayOfWeek = dayMapping[formData.day as keyof typeof dayMapping] || 2
 
       for (let i = 0; i < formData.weeks.length; i++) {
         if (!formData.weeks[i]) continue
@@ -404,6 +405,7 @@ export default function NewCalendarPage() {
         await supabase.from("schedules").insert({
           subject_id: formData.subject_id,
           title: subject.name,
+          day: dayOfWeek,
           start_time: startTime.toISOString(),
           end_time: endTime.toISOString(),
           room: formData.room,

--- a/src/lib/supabase/schema.ts
+++ b/src/lib/supabase/schema.ts
@@ -32,6 +32,7 @@ export interface Schedule {
   end_time: string
   room: string
   campus: string
+  day: number
   week_start: number
   week_end: number
   semester: string  // e.g., "20243" for 2024-2025 semester 3
@@ -39,6 +40,41 @@ export interface Schedule {
   color?: string
   created_at: string
   updated_at: string
+}
+
+/**
+ * Tags table
+ * Allow grouping schedules and exams
+ */
+export interface Tag {
+  id: string
+  name: string
+  type: string
+  color: string
+  is_active: boolean
+  created_at: string
+}
+
+/**
+ * Exams table
+ * Stores exam schedules
+ */
+export interface Exam {
+  id: string
+  subject_id: string
+  subject_code: string
+  subject_name: string
+  group_class: string
+  exam_date: string
+  exam_type: string
+  campus: string
+  room: string
+  day_of_week: number
+  start_time: string
+  duration_minutes: number
+  semester: string
+  tag_id: string
+  created_at: string
 }
 
 /**
@@ -97,6 +133,8 @@ export interface Task {
 export interface DatabaseTables {
   subjects: Subject
   schedules: Schedule
+  exams: Exam
+  tags: Tag
   notes: Note
   lessons: Lesson
   tasks: Task

--- a/supabase-table.md
+++ b/supabase-table.md
@@ -73,6 +73,7 @@ create table public.schedules (
   campus text null,
   week_start integer null,
   week_end integer null,
+  tag_id uuid null references tags(id) on delete cascade,
   color text null,
   notes text null,
   created_at timestamp without time zone null default now(),
@@ -130,4 +131,39 @@ create table public.tasks (
   due_date text not null,
   created_at timestamp with time zone null default now(),
   constraint tasks_pkey primary key (id)
+) TABLESPACE pg_default;
+
+
+tags
+
+create table public.tags (
+  id uuid not null default extensions.uuid_generate_v4 (),
+  name text not null,
+  type text not null default 'manual',
+  color text not null,
+  is_active boolean not null default true,
+  created_at timestamp with time zone null default now(),
+  constraint tags_pkey primary key (id)
+) TABLESPACE pg_default;
+
+
+exams
+
+create table public.exams (
+  id uuid not null default extensions.uuid_generate_v4 (),
+  subject_id uuid references subjects(id) on delete cascade,
+  subject_code text not null,
+  subject_name text not null,
+  group_class text null,
+  exam_date date not null,
+  exam_type text not null,
+  campus text null,
+  room text null,
+  day_of_week integer null,
+  start_time text not null,
+  duration_minutes integer not null,
+  semester text not null,
+  tag_id uuid references tags(id) on delete cascade,
+  created_at timestamp with time zone null default now(),
+  constraint exams_pkey primary key (id)
 ) TABLESPACE pg_default;


### PR DESCRIPTION
## Summary
- update Supabase schema typings
- document new `tags` and `exams` tables in `supabase-table.md`
- store `day` when inserting schedules so filtering works
- adjust weekday mapping

## Testing
- `npm run lint` *(fails: several lint errors across repo)*

------
https://chatgpt.com/codex/tasks/task_e_684e8fd8dae08329935c7e592e8baf71