### PR TITLE
Fix schedule parsing week numbers

### DIFF
--- a/src/app/calendar/new/page.tsx
+++ b/src/app/calendar/new/page.tsx
@@ -159,7 +159,10 @@ export default function NewCalendarPage() {
         if (!match) continue
 
         const [, semester, subjectCode, subjectName, credits, tuitionCredits, group, day, , time, room, campus, weekPattern] = match
-        const weeks = weekPattern.split('|').map((w, index) => w.trim() && w !== '--' ? index + 1 : null).filter(w => w !== null)
+        const weeks = weekPattern
+          .split('|')
+          .map((w, index) => (w.trim() && w !== '--' ? index + 25 : null))
+          .filter((w) => w !== null)
         if (weeks.length === 0 || !day || !time) continue
 
         const timeMatch = time.match(/([\d:]+)\s*-\s*([\d:]+)/)


### PR DESCRIPTION
## Summary
- fix week numbering to match semester weeks when parsing pasted schedules

## Testing
- `npm run lint` *(fails: React/TypeScript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e94fd857c8329acd22260568f3cea