### PR TITLE
Fix schedule form defaults and update migrations

### DIFF
--- a/src/app/calendar/new/page.tsx
+++ b/src/app/calendar/new/page.tsx
@@ -58,7 +58,8 @@ export default function NewCalendarPage() {
     endTime: "",
     room: "",
     campus: "BK-LTK",
-    weeks: Array(9).fill(false).map((_, i) => i + 25 < 34),
+    // Start with no weeks selected
+    weeks: Array(9).fill(false),
     tag_id: ""
   })
 
@@ -159,7 +160,10 @@ export default function NewCalendarPage() {
         if (!match) continue
 
         const [, semester, subjectCode, subjectName, credits, tuitionCredits, group, day, , time, room, campus, weekPattern] = match
-        const weeks = weekPattern.split('|').map((w, index) => w.trim() && w !== '--' ? index + 1 : null).filter(w => w !== null)
+        const weeks = weekPattern
+          .split('|')
+          .map((w, index) => (w.trim() && w !== '--' ? index + 25 : null))
+          .filter((w) => w !== null)
         if (weeks.length === 0 || !day || !time) continue
 
         const timeMatch = time.match(/([\d:]+)\s*-\s*([\d:]+)/)
@@ -296,6 +300,7 @@ export default function NewCalendarPage() {
 
             await supabase.from("schedules").insert({
               subject_id: subjectId,
+              group_name: item.group,
               title: item.subjectName,
               day: dayOfWeek,
               start_time: startTime.toISOString(),

--- a/supabase/migrations/20240613150000_add_calendar_tables.sql
+++ b/supabase/migrations/20240613150000_add_calendar_tables.sql
@@ -1,48 +1,63 @@
--- Thêm cột color vào bảng subjects nếu chưa có
+-- Initialize calendar-related tables
+
+-- Ensure subjects have a color column
 ALTER TABLE subjects
 ADD COLUMN IF NOT EXISTS color TEXT DEFAULT '#3b82f6';
 
--- Tạo bảng schedules
+-- Schedules table
 CREATE TABLE IF NOT EXISTS schedules (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  subject_id UUID REFERENCES subjects(id) ON DELETE CASCADE,
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  subject_id uuid REFERENCES subjects(id) ON DELETE CASCADE,
+  semester TEXT NOT NULL,
   title TEXT NOT NULL,
-  start_time TIMESTAMP WITH TIME ZONE NOT NULL,
-  end_time TIMESTAMP WITH TIME ZONE NOT NULL,
-  week_start INTEGER NOT NULL DEFAULT 1,
-  week_end INTEGER NOT NULL DEFAULT 1,
+  group_name TEXT,
+  day INTEGER,
+  start_time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  end_time TIMESTAMP WITHOUT TIME ZONE NOT NULL,
   room TEXT,
+  campus TEXT,
+  week_start INTEGER,
+  week_end INTEGER,
+  tag_id uuid REFERENCES tags(id) ON DELETE CASCADE,
   color TEXT,
   notes TEXT,
-  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+  created_at TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW()
 );
 
--- Tạo bảng lessons để lưu trữ bài học
+CREATE INDEX IF NOT EXISTS idx_schedules_day_week
+  ON schedules (day, week_start, week_end);
+
+-- Lessons table
 CREATE TABLE IF NOT EXISTS lessons (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  schedule_id UUID REFERENCES schedules(id) ON DELETE CASCADE,
-  content TEXT,
-  files TEXT[],
-  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  subject_id uuid NOT NULL REFERENCES subjects(id) ON DELETE CASCADE,
+  semester TEXT NOT NULL,
+  group_name TEXT NOT NULL,
+  day INTEGER NOT NULL CHECK (day >= 2 AND day <= 8),
+  periods TEXT NOT NULL,
+  time TEXT NOT NULL,
+  room TEXT NOT NULL,
+  campus TEXT NOT NULL,
+  week_pattern TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
 
--- Tạo trigger để cập nhật updated_at
-CREATE OR REPLACE FUNCTION update_modified_column()
-RETURNS TRIGGER AS $$
-BEGIN
-  NEW.updated_at = NOW();
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
+ALTER TABLE lessons
+  ADD CONSTRAINT IF NOT EXISTS lessons_subject_id_day_time_room_key
+    UNIQUE (subject_id, day, "time", room);
 
-DROP TRIGGER IF EXISTS update_schedules_updated_at ON schedules;
-CREATE TRIGGER update_schedules_updated_at
-BEFORE UPDATE ON schedules
-FOR EACH ROW EXECUTE FUNCTION update_modified_column();
+-- Notes table
+CREATE TABLE IF NOT EXISTS notes (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  lesson_id uuid NOT NULL REFERENCES lessons(id) ON DELETE CASCADE,
+  week_number INTEGER NOT NULL CHECK (week_number >= 25 AND week_number <= 33),
+  theory TEXT,
+  exercises TEXT,
+  formulas TEXT,
+  vocabulary TEXT,
+  images TEXT[] DEFAULT ARRAY[]::text[],
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
 
-DROP TRIGGER IF EXISTS update_lessons_updated_at ON lessons;
-CREATE TRIGGER update_lessons_updated_at
-BEFORE UPDATE ON lessons
-FOR EACH ROW EXECUTE FUNCTION update_modified_column();
+CREATE INDEX IF NOT EXISTS idx_notes_lesson_id ON notes(lesson_id);
+CREATE INDEX IF NOT EXISTS idx_notes_week_number ON notes(week_number);


### PR DESCRIPTION
## Summary
- start manual schedule form with no weeks selected
- include `group_name` when saving parsed schedules
- update database migration to align with Supabase schema

## Testing
- `npm run lint` *(fails: React/TypeScript lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e94fd857c8329acd22260568f3cea